### PR TITLE
Add KÉRASTASE pop-up store timeline entry for July 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,29 @@
         <!-- Timeline container -->
         <div class="relative timeline-line pl-2 md:pl-4 space-y-12">
 
+            <!-- Item 13: 202607 -->
+            <div class="timeline-item relative z-10 flex items-start group" data-date="2026.07" data-content="KÉRASTASE pop-up store Seoul appeared kerastase">
+                <!-- Image Circle -->
+                <div class="flex-shrink-0 w-[60px] h-[60px] rounded-full border-4 border-white shadow-md overflow-hidden bg-gray-200 z-10 relative">
+                    <img src="https://placehold.co/100x100/a0c4ff/ffffff?text=Jul" alt="July Image" class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110">
+                </div>
+                <!-- Content -->
+                <div class="ml-6 mt-1 flex-1">
+                    <div class="flex flex-col sm:flex-row sm:items-baseline mb-2">
+                        <span class="font-eng text-2xl font-bold text-blue-400 mr-3">2026.07</span>
+                    </div>
+                    <div class="bg-white p-4 rounded-xl shadow-sm border border-gray-100 hover:shadow-md transition-shadow duration-300">
+                        <p class="text-gray-700 leading-relaxed font-medium">
+                            [2026.07.07] MINJU appears at the KÉRASTASE pop-up store in Seoul.
+                        </p>
+                        <!-- X (Twitter) embed -->
+                        <div class="mt-4 flex justify-center">
+                            <blockquote class="twitter-tweet"><a href="https://x.com/theillitnews_/status/2074726423718445496">Loading...</a></blockquote>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Item 12: 202606 -->
             <div class="timeline-item relative z-10 flex items-start group" data-date="2026.06" data-content="Appointed ambassador cosmetics brand glint">
                 <!-- Image Circle -->


### PR DESCRIPTION
## Summary
Added a new timeline entry documenting MINJU's appearance at the KÉRASTASE pop-up store in Seoul during July 2026.

## Key Changes
- Added a new timeline item (Item 13) positioned at the top of the timeline entries
- Included event date: 2026.07.07
- Added descriptive content about MINJU's appearance at the KÉRASTASE pop-up store
- Embedded a Twitter/X post reference for the event
- Maintained consistent styling with existing timeline items (circular image, date badge, content card with hover effects)

## Implementation Details
- Used the existing timeline component structure with proper z-index and flexbox layout
- Added placeholder image with light blue background color scheme
- Included hover animation effects on the image (scale-110 transform)
- Embedded Twitter blockquote with link to the original post
- Responsive design maintained with sm: breakpoints for mobile/desktop layouts
- Proper spacing and shadow effects consistent with other timeline entries

https://claude.ai/code/session_01TnWxegpmbu12XKQ2HuC26d